### PR TITLE
to avoid $message not be only a string

### DIFF
--- a/src/StderrLogger.php
+++ b/src/StderrLogger.php
@@ -58,7 +58,11 @@ class StderrLogger extends AbstractLogger
 
         $this->openStderr();
 
-        $message = $this->interpolate($message, $context);
+        if (is_string($message)) {
+            $message = $this->interpolate($message, $context);
+        } else {
+            $message = json_encode($message);
+        }
 
         $message = sprintf("[%s] %s\n", strtoupper($level), $message);
 


### PR DESCRIPTION
$logger->warning($param1)
the first parameter can be any type param but interpolate method force it to be a string