### PR TITLE
Use proper methods to stringify exception

### DIFF
--- a/src/StderrLogger.php
+++ b/src/StderrLogger.php
@@ -115,13 +115,6 @@ class StderrLogger extends AbstractLogger
 
     private function logException(\Throwable $exception): void
     {
-        fwrite($this->stream, sprintf(
-            "%s: %s in %s:%d\nStack trace:\n%s\n",
-            get_class($exception),
-            $exception->getMessage(),
-            $exception->getFile(),
-            $exception->getLine(),
-            $exception->getTraceAsString()
-        ));
+        fwrite($this->stream, $exception->__toString());
     }
 }


### PR DESCRIPTION
The current process to stringify exceptions does not produce the same output as if the exception would not have been catched. Especially the lack of parent exceptions makes it very difficult to debug.